### PR TITLE
Release sebex_test_x v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `sebex_test_x` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-	{:sebex_test_x, "~> 0.7.0"}
+	{:sebex_test_x, "~> 0.8.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SebexTestX.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [


### PR DESCRIPTION
### Release "Simply Pro Tick"

| Project | New Version |
|---|---|
| sebex_test_x | `0.8.0` |


<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>